### PR TITLE
dangerous but functional fix to double slave problem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -160,7 +160,7 @@ if node.ipaddress == node.spark.master_ip
   end
 
   service "spark" do
-    action [:enable, :start]
+    action [:enable, :restart]
   end
 end
 


### PR DESCRIPTION
The start command results in multiple instances of a worker process on the slave nodes when called multiple times via a chef recipe.  This is a quick fix.  The logic should be improved but this will work for now.
