### PR TITLE
Quick fix for double worker process problem.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -154,7 +154,8 @@ if node.ipaddress == node.spark.master_ip
         "start_priority" => "70",
         "stop_priority" => "75",
         "start_command" => "#{node.spark.home}/sbin/start-all.sh",
-        "stop_command" => "#{node.spark.home}/sbin/stop-all.sh"
+        "stop_command" => "#{node.spark.home}/sbin/stop-all.sh",
+        "restart_command" => "#{node.spark.home}/sbin/stop-all.sh ; #{node.spark.home}/sbin/start-all.sh"
       })
     end
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -160,7 +160,7 @@ if node.ipaddress == node.spark.master_ip
   end
 
   service "spark" do
-    action [:enable, :start]
+    action [:enable, :restart]
   end
 end
 


### PR DESCRIPTION
When this recipe is called multiple times it started multiple worker processes.  For now, this fixes the issue by restarting the cluster.
