### PR TITLE
wrap environment vars in quotes

### DIFF
--- a/templates/default/conf-spark-env.sh.erb
+++ b/templates/default/conf-spark-env.sh.erb
@@ -45,7 +45,7 @@
 # Auto generate variables from Spark Chef Cookbook
 <% @env_vars.each do |key, value| %>
 <% if !key.nil? && !value.nil? %>
-<%= key %>=<%= value %>
+<%= key %>="<%= value %>"
 <% end %>
 <% end %>
 


### PR DESCRIPTION
For multi-word strings.  @brenttheisen for your review.
